### PR TITLE
fix(anpa-formatter) Stop it modifying the article body and fix format

### DIFF
--- a/server/aap/publish/formatters/anpa_formatter.py
+++ b/server/aap/publish/formatters/anpa_formatter.py
@@ -116,14 +116,16 @@ class AAPAnpaFormatter(Formatter):
                     soup = BeautifulSoup(self.append_body_footer(article), "html.parser")
                     anpa.append(soup.get_text().encode('ascii', 'replace'))
                 else:
+                    body = article.get('body_html', '')
+                    # we need to inject the dateline
                     if is_first_part and article.get('dateline', {}).get('text'):
-                        soup = BeautifulSoup(article.get('body_html', ''), "html.parser")
+                        soup = BeautifulSoup(body, "html.parser")
                         ptag = soup.find('p')
                         if ptag is not None:
                             ptag.insert(0, NavigableString(
                                 '{} '.format(article.get('dateline').get('text')).encode('ascii', 'ignore')))
-                            article['body_html'] = str(soup)
-                    anpa.append(self.to_ascii(article.get('body_html', '')))
+                            body = str(soup)
+                    anpa.append(self.to_ascii(body))
                     if article.get('body_footer'):
                         anpa.append(self.to_ascii(article.get('body_footer', '')))
 
@@ -159,7 +161,7 @@ class AAPAnpaFormatter(Formatter):
         soup = BeautifulSoup(html, "html.parser")
         text = StringIO()
         for p in soup.findAll('p'):
-            text.write('\r\n   ')
+            text.write('   ')
             ptext = p.get_text('\n')
             for l in ptext.split('\n'):
                 text.write(l + '\r\n')

--- a/server/aap/publish/formatters/anpa_formatter_test.py
+++ b/server/aap/publish/formatters/anpa_formatter_test.py
@@ -79,11 +79,9 @@ class ANPAFormatterTest(SuperdeskTestCase):
         line = lines.readline()
         self.assertEqual(line.strip(), 'slugline take_key')
 
-        lines.readline()
         line = lines.readline()
         self.assertEqual(line.strip(), 'The story body')
 
-        lines.readline()
         line = lines.readline()
         self.assertEqual(line.strip(), 'call helpline 999 if you are planning')
 
@@ -117,11 +115,9 @@ class ANPAFormatterTest(SuperdeskTestCase):
         line = lines.readline()
         self.assertEqual(line.strip(), 'slugline take_key')
 
-        lines.readline()
         line = lines.readline()
         self.assertEqual(line.strip(), 'The story body')
 
-        lines.readline()
         line = lines.readline()
         self.assertEqual(line.strip(), 'call helpline 999 if you are planning')
 
@@ -160,11 +156,9 @@ class ANPAFormatterTest(SuperdeskTestCase):
         line = lines.readline()
         self.assertEqual(line.strip(), 'Joe Blogs')
 
-        lines.readline()
         line = lines.readline()
         self.assertEqual(line.strip(), 'The story body')
 
-        lines.readline()
         line = lines.readline()
         self.assertEqual(line.strip(), 'call helpline 999 if you are planning')
 


### PR DESCRIPTION
Stops duplication of dateline in other outputs!!!
