### PR TITLE
Setting the default content expiry to 3 days

### DIFF
--- a/server/settings.py
+++ b/server/settings.py
@@ -201,3 +201,6 @@ ELASTICSEARCH_AUTO_AGGREGATIONS = False
 
 # This setting is used to overide the desk/stage expiry for items to expire from the spike
 SPIKE_EXPIRY_MINUTES = int(env('SPIKE_EXPIRY_MINUTES', 3 * 24 * 60))
+
+#: The number of minutes before content items are purged (3 days)
+CONTENT_EXPIRY_MINUTES = int(env('CONTENT_EXPIRY_MINUTES', 3 * 24 * 60))


### PR DESCRIPTION
This value has been changed in core to 30 days so keeping here as 3 days: 
https://github.com/superdesk/superdesk-core/pull/598#pullrequestreview-3816266
