### PR TITLE
[SDESK-355] - Newsml G2 formatter is added to text type formatters

### DIFF
--- a/server/data/vocabularies.json
+++ b/server/data/vocabularies.json
@@ -181,7 +181,8 @@
                 "formats": [{"name": "NINJS", "qcode": "ninjs"}, {"name": "AAP NewsML 1.2", "qcode": "newsml12"}, {"name": "NewsML G2", "qcode": "newsmlg2"},
                             {"name": "AAP Bulletin Builder", "qcode": "AAP BULLETIN BUILDER"}]},
             {"is_active": true, "name": "Wire/Paper", "qcode": "wire",
-                "formats": [{"name": "AAP ANPA", "qcode": "AAP ANPA"}, {"name": "AAP NewsML 1.2", "qcode": "newsml12"}, {"name": "NITF", "qcode": "nitf"}, {"name": "AAP IPNEWS", "qcode": "AAP IPNEWS"},
+                "formats": [{"name": "AAP ANPA", "qcode": "AAP ANPA"}, {"name": "AAP NewsML 1.2", "qcode": "newsml12"}, {"name": "NewsML G2", "qcode": "newsmlg2"},
+                            {"name": "NITF", "qcode": "nitf"}, {"name": "AAP IPNEWS", "qcode": "AAP IPNEWS"},
                             {"name": "AAP SMS", "qcode": "AAP SMS"}, {"name": "AAP NEWSCENTRE", "qcode": "AAP NEWSCENTRE"},
                             {"name": "NZN NEWSCENTRE", "qcode":"NZN NEWSCENTRE"}, {"name":"NZN IPNEWS", "qcode": "NZN IPNEWS"},
                             {"name": "NZN ANPA", "qcode": "NZN ANPA"}, {"name": "Email", "qcode": "Email"}, {"name": "AAP NITF", "qcode": "aap_nitf"}]}


### PR DESCRIPTION
- I have added the following to the UAT vocabularies > subscriber_types > wire/paper > formats
```{"name" : "NewsML G2", "qcode" : "newsmlg2"}```
- The same needs to be done when this is released to Production.