### PR TITLE
[sdesk-1482] Handle content with a single div parent

### DIFF
--- a/server/aap/publish/formatters/aap_bulletinbuilder_formatter.py
+++ b/server/aap/publish/formatters/aap_bulletinbuilder_formatter.py
@@ -18,7 +18,7 @@ from superdesk.errors import FormatterError
 from superdesk.metadata.item import ITEM_TYPE, PACKAGE_TYPE, ITEM_STATE, CONTENT_STATE, ASSOCIATIONS, CONTENT_TYPE
 from .field_mappers.locator_mapper import LocatorMapper
 from .field_mappers.slugline_mapper import SluglineMapper
-from .aap_formatter_common import set_subject
+from .aap_formatter_common import set_subject, get_tag_list
 from .unicodetoascii import to_ascii
 from copy import deepcopy
 import json
@@ -122,7 +122,7 @@ class AAPBulletinBuilderFormatter(Formatter):
         etree.strip_elements(parsed, 'br', with_tail=False)
 
         text = ''
-        for top_level_tag in parsed.xpath('/html/div/child::*'):
+        for top_level_tag in get_tag_list(parsed):
             text += self.format_text_content(top_level_tag)
 
         return re.sub(' +', ' ', text)

--- a/server/aap/publish/formatters/aap_bulletinbuilder_formatter_tests.py
+++ b/server/aap/publish/formatters/aap_bulletinbuilder_formatter_tests.py
@@ -653,3 +653,79 @@ class AapBulletinBuilderFormatterTest(TestCase):
         self.assertEqual(test_article['associations']['featuremedia']['alt_text'], 'Hello world')
         self.assertEqual(test_article['associations']['featuremedia']['slugline'], 'Hello world')
         self.assertEqual(test_article['associations']['featuremedia']['byline'], 'Hello world')
+
+    def test_content_wrapped_in_a_div(self):
+        article = {
+            'source': 'AAP',
+            'anpa_category': [{'qcode': 's'}],
+            'headline': 'This is a test headline',
+            'byline': 'joe',
+            'slugline': 'slugline',
+            'subject': [{'qcode': '15017000'}],
+            'anpa_take_key': 'take_key',
+            'unique_id': '1',
+            'type': 'text',
+            "format": "HTML",
+            'body_html': '<div><p>Giants Netball have won through to the inaugural Super Netball grand '
+                         'final with a clinical 65-57 victory over Melbourne Vixens at Hisense Arena on Saturday '
+                         'night.</p><p>The eight-goal win secures the Giants a grand final berth against Sunshine '
+                         'Coast Lightning at Brisbane Entertainment Centre next Saturday. </p><p>It wasn''t to be for '
+                         'the Vixens who completed the regular season as minor premiers but lost both of their finals '
+                         'matches.</p><p>Kristina Brice began the season on the Giants bench but showed she has the '
+                         'skill and composure of a strike shooter with a match-high 42 goals, from 44 attempts at 95 '
+                         'per cent accuracy.</p></div>',
+            'word_count': '1',
+            'priority': '1',
+            'firstcreated': utcnow(),
+            'versioncreated': utcnow(),
+            'lock_user': ObjectId(),
+            'task': {
+                'desk': self.desks[0][config.ID_FIELD]
+            }
+        }
+
+        subscriber = self.app.data.find('subscribers', None, None)[0]
+        seq, item = self._formatter.format(article, subscriber)[0]
+        item = json.loads(item)
+        self.assertGreater(int(seq), 0)
+        test_article = json.loads(item.get('data'))
+        self.maxDiff = None
+        self.assertEqual(test_article['body_text'],
+                         'Giants Netball have won through to the inaugural Super Netball grand final with a clinical '
+                         '65-57 victory over Melbourne Vixens at Hisense Arena on Saturday night.\r\n\r\nThe eight-goal'
+                         ' win secures the Giants a grand final berth against Sunshine Coast Lightning at Brisbane '
+                         'Entertainment Centre next Saturday.\r\n\r\nIt wasn''t to be for the Vixens who completed the '
+                         'regular season as minor premiers but lost both of their finals matches.\r\n\r\nKristina Brice'
+                         ' began the season on the Giants bench but showed she has the skill and composure of '
+                         'a strike shooter with a match-high 42 goals, from 44 attempts at 95 per cent '
+                         'accuracy.\r\n\r\n')
+
+    def test_content_wrapped_in_a_div_with_no_children(self):
+        article = {
+            'source': 'AAP',
+            'anpa_category': [{'qcode': 's'}],
+            'headline': 'This is a test headline',
+            'byline': 'joe',
+            'slugline': 'slugline',
+            'subject': [{'qcode': '15017000'}],
+            'anpa_take_key': 'take_key',
+            'unique_id': '1',
+            'type': 'text',
+            "format": "HTML",
+            'body_html': '<div>stuff</div>',
+            'word_count': '1',
+            'priority': '1',
+            'firstcreated': utcnow(),
+            'versioncreated': utcnow(),
+            'lock_user': ObjectId(),
+            'task': {
+                'desk': self.desks[0][config.ID_FIELD]
+            }
+        }
+
+        subscriber = self.app.data.find('subscribers', None, None)[0]
+        seq, item = self._formatter.format(article, subscriber)[0]
+        item = json.loads(item)
+        self.assertGreater(int(seq), 0)
+        test_article = json.loads(item.get('data'))
+        self.assertEqual(test_article['body_text'], 'stuff\r\n\r\n')

--- a/server/aap/publish/formatters/aap_formatter_common.py
+++ b/server/aap/publish/formatters/aap_formatter_common.py
@@ -69,3 +69,11 @@ def get_service_level(category, article):
         return category.get('qcode', 'a').lower()
 
     return 'a'
+
+
+def get_tag_list(parsed):
+    tag_list = parsed.xpath('/html/div/child::*')
+    # In some rare cases we get an article with the content wrapped in a single div
+    if len(tag_list) == 1 and tag_list[0].tag == 'div' and len(list(tag_list[0])) > 0:
+        tag_list = list(tag_list[0])
+    return tag_list

--- a/server/aap/publish/formatters/aap_ipnews_formatter.py
+++ b/server/aap/publish/formatters/aap_ipnews_formatter.py
@@ -115,7 +115,7 @@ class AAPIpNewsFormatter(Formatter, AAPODBCFormatter):
             br.tail = '\r\n' + br.tail if br.tail else '\r\n'
         etree.strip_elements(parsed, 'br', with_tail=False)
 
-        for tag in parsed.xpath('/html/div/child::*'):
+        for tag in self.get_tag_list(parsed):
             ptext = ''
             for x in tag.itertext():
                 ptext += x

--- a/server/aap/publish/formatters/aap_ipnews_formatter_test.py
+++ b/server/aap/publish/formatters/aap_ipnews_formatter_test.py
@@ -899,6 +899,80 @@ class AapIpNewsFormatterTest(TestCase):
         item = json.loads(item)
         self.assertEqual(item['article_text'], '\x19   By joe\x19\r\na&b\r\nAAP')
 
+    def test_aap_newscentre_formatter_with_parent_div(self):
+        subscriber = self.app.data.find('subscribers', None, None)[0]
+        article = {
+            "_id": "1",
+            "pubstatus": "usable",
+            "format": "HTML",
+            "subject": [
+                {
+                    "qcode": "15042000",
+                    "name": "netball",
+                    "parent": "15000000"
+                }
+            ],
+            "dateline": {
+                "text": "MELBOURNE, June 10 AAP -",
+                "source": "AAP",
+                "located": {
+                    "state_code": "VIC",
+                    "alt_name": "",
+                    "country_code": "AU",
+                    "tz": "Australia/Melbourne",
+                    "dateline": "city",
+                    "country": "Australia",
+                    "state": "Victoria",
+                    "city": "Melbourne",
+                    "city_code": "Melbourne"
+                }
+            },
+            "genre": [
+                {
+                    "name": "Article (news)",
+                    "qcode": "Article"
+                }
+            ],
+            "type": "text",
+            "priority": 6,
+            "place": [
+                {
+                    "name": "VIC",
+                    "group": "Australia",
+                    "world_region": "Oceania",
+                    "country": "Australia",
+                    "qcode": "VIC",
+                    "state": "Victoria"
+                }
+            ],
+            "byline": "Samantha Sonogan",
+            "source": "AAP",
+            "state": "published",
+            "slugline": "Net Vixens",
+            "anpa_category": [
+                {
+                    "name": "Domestic Sport",
+                    "qcode": "A",
+                    "subject": "15000000"
+                }
+            ],
+            "headline": "Giants beat Vixens to reach netball GF",
+            "body_html": "<div><p>Giants Netball have won through to the inaugural Super Netball grand "
+                         "final with a clinical 65-57 victory over Melbourne Vixens at Hisense Arena on Saturday "
+                         "night.</p><p>The eight-goal win secures the Giants a grand final berth against Sunshine "
+                         "Coast Lightning at Brisbane Entertainment Centre next Saturday. </p><p>It wasn’t to be for "
+                         "the Vixens who completed the regular season as minor premiers but lost both of their finals "
+                         "matches.</p><p>Kristina Brice began the season on the Giants bench but showed she has the "
+                         "skill and composure of a strike shooter with a match-high 42 goals, from 44 attempts at 95 "
+                         "per cent accuracy.</p></div>",
+        }
+
+        f = AAPIpNewsFormatter()
+        seq, item = f.format(article, subscriber, ['Axx'])[0]
+        item = json.loads(item)
+        self.assertTrue(item['article_text'].startswith('   By Samantha Sonogan\r\n   MELBOURNE, June 10 AAP - '
+                                                        'Giants Netball'))
+
 
 class DefaultSubjectTest(TestCase):
 

--- a/server/aap/publish/formatters/aap_newscentre_formatter.py
+++ b/server/aap/publish/formatters/aap_newscentre_formatter.py
@@ -104,7 +104,7 @@ class AAPNewscentreFormatter(Formatter, AAPODBCFormatter):
             br.tail = '\r\n' + br.tail if br.tail else '\r\n'
         etree.strip_elements(parsed, 'br', with_tail=False)
 
-        for tag in parsed.xpath('/html/div/child::*'):
+        for tag in self.get_tag_list(parsed):
             ptext = ''
             for x in tag.itertext():
                 ptext += x

--- a/server/aap/publish/formatters/aap_newscentre_formatter_test.py
+++ b/server/aap/publish/formatters/aap_newscentre_formatter_test.py
@@ -103,8 +103,8 @@ class AapNewscentreFormatterTest(TestCase):
         item = json.loads(item)
 
         expected = '   By joe\r\n\r\n   The story body line 1\r\nLine 2\r\n\r\n   abcdefghi ' \
-            'abcdefghi abcdefghi abcdefghi abcdefghi ' + \
-            'abcdefghi abcdefghi abcdefghi more\r\n\r\n\r\nAAP'
+                   'abcdefghi abcdefghi abcdefghi abcdefghi ' + \
+                   'abcdefghi abcdefghi abcdefghi more\r\n\r\n\r\nAAP'
         self.assertEqual(item['article_text'], expected)
 
     def testMultipleCategories(self):
@@ -212,11 +212,105 @@ class AapNewscentreFormatterTest(TestCase):
                               'headline': 'VIC:This is a test headline', 'originator': 'AAP',
                               'take_key': 'take_key',
                               'article_text': '   By joe\r\n\r\nThe story body\r\ncall helpline 999 if you are '
-                              'planning '
-                              'to quit smoking\r\nAAP',
+                                              'planning '
+                                              'to quit smoking\r\nAAP',
                               'usn': '1',
                               'subject_matter': 'international law', 'news_item_type': 'News',
                               'subject_reference': '02011001', 'subject': 'crime, law and justice',
                               'subject_detail': 'international court or tribunal',
                               'selector_codes': 'AXX',
                               'genre': 'Current', 'keyword': 'slugline', 'author': 'joe'})
+
+    def test_aap_newscentre_formatter_with_parent_div(self):
+        subscriber = self.app.data.find('subscribers', None, None)[0]
+        article = {
+            "_id": "1",
+            "pubstatus": "usable",
+            "format": "HTML",
+            "subject": [
+                {
+                    "qcode": "15042000",
+                    "name": "netball",
+                    "parent": "15000000"
+                }
+            ],
+            "dateline": {
+                "text": "MELBOURNE, June 10 AAP -",
+                "source": "AAP",
+                "located": {
+                    "state_code": "VIC",
+                    "alt_name": "",
+                    "country_code": "AU",
+                    "tz": "Australia/Melbourne",
+                    "dateline": "city",
+                    "country": "Australia",
+                    "state": "Victoria",
+                    "city": "Melbourne",
+                    "city_code": "Melbourne"
+                }
+            },
+            "genre": [
+                {
+                    "name": "Article (news)",
+                    "qcode": "Article"
+                }
+            ],
+            "type": "text",
+            "priority": 6,
+            "item_id": "tag:localhost:2017:ade7bae3-bb1a-44d4-bc13-f7b863b9fbf9",
+            "original_source": "Samantha Sonogan <samantha.sonogan@gmail.com>",
+            "abstract": "<p>Giants Netball have defeated Melbourne Vixens by eight goals to set up a Super Netball "
+                        "grand final showdown against Sunshine Coast Lightning next weekend.</p>",
+            "anpa_take_key": "Wrap",
+            "event_id": "tag:localhost:2017:c48df4b8-8965-4446-b085-d3ae795a3ca7",
+            "family_id": "urn:newsml:localhost:2017-06-10T20:56:13.982005:6aa08c6c-5e3b-418f-bc39-cfbddb31af54",
+            "place": [
+                {
+                    "name": "VIC",
+                    "group": "Australia",
+                    "world_region": "Oceania",
+                    "country": "Australia",
+                    "qcode": "VIC",
+                    "state": "Victoria"
+                }
+            ],
+            "byline": "Samantha Sonogan",
+            "digital_item_id": "tag:localhost:2017:ade7bae3-bb1a-44d4-bc13-f7b863b9fbf9",
+            "original_creator": "",
+            "source": "AAP",
+            "state": "published",
+            "slugline": "Net Vixens",
+            "sms_message": "",
+            "_etag": "9ece6fa87efa28765e3e3aea1c87b4321f19c7f3",
+            "language": "en",
+            "unique_name": "#12151006",
+            "ingest_id": "urn:newsml:localhost:2017-06-10T20:56:13.982005:6aa08c6c-5e3b-418f-bc39-cfbddb31af54",
+            "anpa_category": [
+                {
+                    "name": "Domestic Sport",
+                    "qcode": "A",
+                    "subject": "15000000"
+                }
+            ],
+            "headline": "Giants beat Vixens to reach netball GF",
+            "profile": "58b788bd069b7f6953927e9d",
+            "queue_state": "queued",
+            "body_html": "<div class=\"\"><p>Giants Netball have won through to the inaugural Super Netball grand "
+                         "final with a clinical 65-57 victory over Melbourne Vixens at Hisense Arena on Saturday "
+                         "night.</p><p>The eight-goal win secures the Giants a grand final berth against Sunshine "
+                         "Coast Lightning at Brisbane Entertainment Centre next Saturday. </p><p>It wasn’t to be for "
+                         "the Vixens who completed the regular season as minor premiers but lost both of their finals "
+                         "matches.</p><p>Kristina Brice began the season on the Giants bench but showed she has the "
+                         "skill and composure of a strike shooter with a match-high 42 goals, from 44 attempts at 95 "
+                         "per cent accuracy.</p></div>",
+            "operation": "publish",
+            "sign_off": "TK",
+            "ingest_provider_sequence": "5569",
+            "rewritten_by": "urn:newsml:localhost:2017-06-10T21:41:14.783739:68340e20-13c2-4116-aefb-201a7d097117"
+        }
+
+        f = AAPNewscentreFormatter()
+        seq, item = f.format(article, subscriber, ['Axx'])[0]
+        item = json.loads(item)
+        self.assertTrue(
+            item['article_text'].startswith('   By Samantha Sonogan\r\n\r\n   MELBOURNE, June 10 AAP - Giants Netball'))

--- a/server/aap/publish/formatters/aap_nitf_formatter.py
+++ b/server/aap/publish/formatters/aap_nitf_formatter.py
@@ -16,6 +16,7 @@ from lxml.etree import SubElement
 import re
 from .unicodetoascii import to_ascii
 from superdesk.etree import parse_html, get_text, to_string
+from .aap_formatter_common import get_tag_list
 
 
 class AAPNITFFormatter(NITFFormatter):
@@ -92,7 +93,7 @@ class AAPNITFFormatter(NITFFormatter):
         html = html.replace('\n', ' ')
         html = re.sub(r'\s\s+', ' ', html)
         parsed = parse_html(html, content='html')
-        for tag in parsed.xpath('/html/div/child::*'):
+        for tag in get_tag_list(parsed):
             p = etree.Element('p')
             p.text = to_ascii(get_text(to_string(tag, method='html'), content='html'))
             element.append(p)

--- a/server/aap/publish/formatters/aap_nitf_formatter_test.py
+++ b/server/aap/publish/formatters/aap_nitf_formatter_test.py
@@ -353,3 +353,33 @@ class AAPNitfFormatterTest(TestCase):
         resp = self.formatter.format(article, {'name': 'Test Subscriber'})[0]
         nitf_xml = etree.fromstring(resp['formatted_item'])
         self.assertIsNone(nitf_xml.find('head/meta[@name="anpa-takekey"]'))
+
+    def test_content_wrapped_in_div(self):
+        article = {
+            '_id': '3',
+            'source': 'AAP',
+            'anpa_category': [{'qcode': 'a'}],
+            'headline': 'This is a test headline',
+            'byline': None,
+            'slugline': 'slugline',
+            'subject': [{'qcode': '02011001'}],
+            'anpa_take_key': None,
+            'unique_id': '1',
+            'type': 'text',
+            'body_html': '<div><p>Giants Netball have won through to the inaugural Super Netball grand '
+                         'final with a clinical 65-57 victory over Melbourne Vixens at Hisense Arena on Saturday '
+                         'night.</p><p>The eight-goal win secures the Giants a grand final berth against Sunshine '
+                         'Coast Lightning at Brisbane Entertainment Centre next Saturday. </p><p>It wasn''t to be for '
+                         'the Vixens who completed the regular season as minor premiers but lost both of their finals '
+                         'matches.</p><p>Kristina Brice began the season on the Giants bench but showed she has the '
+                         'skill and composure of a strike shooter with a match-high 42 goals, from 44 attempts at 95 '
+                         'per cent accuracy.</p></div>',
+            'word_count': '1',
+            'priority': 1
+        }
+        resp = self.formatter.format(article, {'name': 'Test Subscriber'})[0]
+        nitf_xml = etree.fromstring(resp['formatted_item'])
+        self.assertEqual(nitf_xml.findall('body/body.content/p')[1].text, 'The eight-goal win secures the Giants a '
+                                                                          'grand final berth against Sunshine Coast '
+                                                                          'Lightning at Brisbane Entertainment '
+                                                                          'Centre next Saturday. ')

--- a/server/aap/publish/formatters/aap_odbc_formatter.py
+++ b/server/aap/publish/formatters/aap_odbc_formatter.py
@@ -9,7 +9,7 @@
 # at https://www.sourcefabric.org/superdesk/license
 from superdesk.io.iptc import subject_codes
 from apps.packages import TakesPackageService
-from .aap_formatter_common import set_subject
+from .aap_formatter_common import set_subject, get_tag_list
 from .field_mappers.locator_mapper import LocatorMapper
 from .field_mappers.slugline_mapper import SluglineMapper
 from eve.utils import config
@@ -123,3 +123,6 @@ class AAPODBCFormatter():
 
     def is_first_part(self, article):
         return article.get('sequence', 1) == 1
+
+    def get_tag_list(self, parsed):
+        return get_tag_list(parsed)

--- a/server/aap/publish/formatters/anpa_formatter.py
+++ b/server/aap/publish/formatters/anpa_formatter.py
@@ -9,7 +9,7 @@
 # at https://www.sourcefabric.org/superdesk/license
 from copy import deepcopy
 from superdesk.publish.formatters import Formatter
-from .aap_formatter_common import map_priority, get_service_level
+from .aap_formatter_common import map_priority, get_service_level, get_tag_list
 import superdesk
 from superdesk.errors import FormatterError
 import datetime
@@ -157,7 +157,7 @@ class AAPAnpaFormatter(Formatter):
             br.tail = '\r\n' + br.tail if br.tail else '\r\n'
         etree.strip_elements(parsed, 'br', with_tail=False)
 
-        for tag in parsed.xpath('/html/div/child::*'):
+        for tag in get_tag_list(parsed):
             if tag.tag not in ('br') and tag.text is not None and tag.text.strip() != '':
                 tag.text = '   ' + re.sub(' +', ' ', re.sub('(?<!\r)\n+', ' ', tag.text)) if tag.text else ''
                 tag.tail = '\r\n' + tag.tail if tag.tail else '\r\n'

--- a/server/aap/publish/formatters/anpa_formatter_test.py
+++ b/server/aap/publish/formatters/anpa_formatter_test.py
@@ -387,3 +387,28 @@ class ANPAFormatterTest(TestCase):
         lines = io.StringIO(out.decode())
         self.assertTrue(lines.getvalue().split('\r')[3].lstrip(), 'Test line 1')
         self.assertTrue(lines.getvalue().split('\r')[4], 'Test line 2')
+
+    def test_content_wrappedin_div(self):
+        f = AAPAnpaFormatter()
+        subscriber = self.app.data.find('subscribers', None, None)[0]
+        item = self.article.copy()
+        item.update({
+            'body_html': '<div><p>Giants Netball have won through to the inaugural Super Netball grand '
+                         'final with a clinical 65-57 victory over Melbourne Vixens at Hisense Arena on Saturday '
+                         'night.</p><p>The eight-goal win secures the Giants a grand final berth against Sunshine '
+                         'Coast Lightning at Brisbane Entertainment Centre next Saturday. </p><p>It wasn’t to be for '
+                         'the Vixens who completed the regular season as minor premiers but lost both of their finals '
+                         'matches.</p><p>Kristina Brice began the season on the Giants bench but showed she has the '
+                         'skill and composure of a strike shooter with a match-high 42 goals, from 44 attempts at 95 '
+                         'per cent accuracy.</p></div>',
+            'format': 'HTML'})
+        resp = f.format(item, subscriber)[0]
+        out = resp['encoded_item']
+        lines = io.StringIO(out.decode())
+        self.assertTrue(lines.getvalue().split('\r')[3].lstrip(), '\n   Giants Netball have won through to the '
+                                                                  'inaugural Super Netball grand final with a '
+                                                                  'clinical 65-57 victory over Melbourne Vixens at '
+                                                                  'Hisense Arena on Saturday night.')
+        self.assertTrue(lines.getvalue().split('\r')[4], '\n   The eight-goal win secures the Giants a grand final '
+                                                         'berth against Sunshine Coast Lightning at Brisbane '
+                                                         'Entertainment Centre next Saturday. ')


### PR DESCRIPTION
Not sure if we need this PR as the problem can be avoided by calling the "extract html macro" in the routing rules of the content from the email ingest.