### PR TITLE
SDAAP-17 Metadata/vocabularies management doesn't list items

### DIFF
--- a/server/settings.py
+++ b/server/settings.py
@@ -73,6 +73,7 @@ INSTALLED_APPS = [
     'aap.fuel',
     'aap.traffic_incidents',
     'aap.subscriber_transmit_references',
+    'apps.languages',
 ]
 
 RENDITIONS = {


### PR DESCRIPTION
This may not be the way to address this. It seems that the languages endpoint is not a core app, but of you don't have it you can't edit the vocabularies. Maybe it should be core or the front end should handle a 404 nicely. Don't seem to require and entry in the vocabularies an empty response is fine.